### PR TITLE
Update droneModels.js

### DIFF
--- a/droneModels.js
+++ b/droneModels.js
@@ -42,6 +42,13 @@ export default [
     imageWidth: 4000,
     imageHeight: 3000
   }, {
+    name: 'DJI Mini 3 Pro (12 MP)',
+    sensorWidth: 9.7,
+    sensorHeight: 7.3,
+    focalLength: 6.72,
+    imageWidth: 4032,
+    imageHeight: 3024
+  }, {
     name: 'DJI Mavic AIR 2',
     sensorWidth: 6.4,
     sensorHeight: 4.8,


### PR DESCRIPTION
Added camera specs for DJI Mini 3 Pro (12 MP).
References [here](https://support.dronelink.com/hc/en-us/community/posts/15924988663699-Mavic-Mini-3-pro-Mapping-Camera) and [here](https://support.dronelink.com/hc/en-us/community/posts/15920675909011-Dronelink-DJI-version-4-5-0-247-DJI-Mini-3-Pro-Drone-Specs-added).